### PR TITLE
Resolve some number related issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ c89: CFLAGS += -std=c89 -Dinline=
 c89: picrin
 
 m32: CFLAGS += -m32
+m32: LDFLAGS += -ledit -lncurses
 m32: picrin
 
 tiny-picrin: CFLAGS += -O0 -g -DPIC_USE_LIBRARY=0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img width="500" src="https://raw.githubusercontent.com/picrin-scheme/picrin/master/etc/picrin-logo-fin01-02.png"></img>
+<img width="500" src="https://raw.githubusercontent.com/picscheme/picscheme/master/etc/picrin-logo-fin01-02.png"></img>
 # Picscheme
 Picscheme is a direct fork of the [picrin](https://github.com/picrin-scheme/picrin)
 project with the initial goal of reviving and maintaining the project.
@@ -39,15 +39,17 @@ To build picscheme Scheme from source code, some external libraries and tools ar
 - regex.h of POSIX.1
 - libedit (optional, requires pkg-config support, see contrib/30.readline/nitro.mk)
 - gmake or compatible make command
+- compiler support for 64bit when compiling for a 32bit system
 
 In c89 mode there are a couple of additional dependencies. These are standard in c99 and later.
 
 - getaddrinfo
-- posix_memalign
+- posix\_memalign
+- round and trunc 
 
 The make command automatically turns on optional libraries if available.
 Picscheme is mainly developed on Mac OS X and only tested on OS X, Ubuntu 14.04+ and Arch Linux
-as of 1-August-2025.
+from the 1-August-2025.
 
 When you try to run picscheme on other platforms and find issues please raise an issue.
 
@@ -68,8 +70,8 @@ To test the dymamic library build tiny-scheme with
 ```
 make clean
 make dlib
-ln -s libpicrin.1.0.0 libpicrin.1.0
-ln -s libpicrin.1.0.0 libpicrin.1
+ln -s libpicrin.so.1.0.0 libpicrin.so.1.0
+ln -s libpicrin.so.1.0.0 libpicrin.so.1
 gcc -o tiny-scheme -I lib/include src/tiny-main.c -L. -lpicrin -lm
 LD_LIBRARY_PATH=$PWD ./tiny-scheme
 ```
@@ -83,27 +85,64 @@ configure the names
 
 See `AUTHORS`
 
-# Lisp for microcontollers
-While picscheme is small it does not currently fit on nor compile for microcontrollers.
-If you are interested in lisp/scheme for microcontrollers head over
-to [ulist](http://www.ulisp.com)
-
-
+# Additonal Notes
 ## C89 mode
 The project is written in c89 c and compiles cleanly with gcc -std=c89.
 However, there a few library references that are not part of the c89
 standard:
 * lib/gc.c uses posix\_memalign
 * srfi-106 requires getaddrinfo (see contrib/40.srfi/src/106.c)
+* contrib/10.math/math.c requires round and trunc 
 
 These are generally available in modern OSes. If this is not the case
 * For gc.c define 'PIC\_BITMAP\_GC=0' in the Makefile CFLAGS
 * Disable srfi-106: This will need source changes in the contrib tree
+* For round and trunc update contrib/10.math/math.c to remove dependencies
 
 In general unless a c89 compiler is the only one available a more
 recent one should be used.
 
+## 32 Bit builds
+The original picrin had some dependencies on 64bits and sometimes assumed
+long was larger than int, these are being identified and resolved. 
+
+### Building 32 bit binaries on 64 bit machines
+Some OSes, especially Arch Linux, are missing 32 bit versions of libedit on 64bit machines.
+To resolve on systems that use pkg-config, download libedit from [thrysoee.dk](https://thrysoee.dk/editline/),
+then,
+* unpack the tarball libedit-VERSION.tar.gz
+* cd libedit-VERSION
+```
+INSTALL_DIR=PATH-TO-INSTALL-DIR
+./configure --prefix=$INSTALL_DIR --disable-shared CFLAGS="-m32"
+make
+make install
+```
+Then in the picrin directory
+```
+export PKG_CONFIG_PATH=$INSTALL_DIR/lib/pkgconfig
+make m32
+```
+
+## Lisp for microcontollers
+While picscheme is small it does not currently fit on nor compile for microcontrollers.
+If you are interested in lisp/scheme for microcontrollers head over
+to [ulist](http://www.ulisp.com)
+
 ## Changes
+
+### September 2025
+* string->number and related functions assumed long was larger than int,
+  which is not always the case on 32bit systems. Used int64 instead
+* Overflow of strtoll handled via errno to improve reliability
+* In setup.h include stdint.h in all cases for int64_t and uint64_t types
+  * int64_t and uint64_t now unconditionally defined in stdint.h
+* When !PIC_USE_LIBC
+  * add strtoll function
+  * handle overflow in existing strtol and new strtoll setting value to INT/LONG_MAX and setting errno
+* Removed c89trunc and c89round as they had limited range
+  * Now use the system libraries
+* Export display from scheme base, write exported in previous update
 
 ### August 2025
 * Tidy up of compiler warnings in non-c89 mode

--- a/contrib/10.math/math.c
+++ b/contrib/10.math/math.c
@@ -4,17 +4,8 @@
 #include <math.h>
 
 #ifndef __STDC_VERSION__
-static double c89trunc(double x) {
-  return (double)((int)x);
-}
-
-static double c89round(double x) {
-  if (x >= 0.0) {
-      return (double)(((x - (int)x) < 0.5) ? (int)x : (int)x + 1);
-  } else {
-      return (double)(((x - (int)x) > -0.5) ? (int)x : (int)x - 1);
-  }
-}
+extern double trunc(double x);
+extern double round(double x);
 
 static int c89isinf(double x) {
   if (x == HUGE_VAL) return 1;
@@ -24,8 +15,6 @@ static int c89isinf(double x) {
 
 #define c89isnan(x) ((x) != (x))
 #else
-#define c89trunc(x) trunc(x)
-#define c89round(x) round(x)
 #define c89isinf(x) isinf(x)
 #define c89isnan(x) isnan(x)
 #endif /* __STDC_VERSION__ */
@@ -68,7 +57,7 @@ pic_number_trunc2(pic_state *pic)
   } else {
     double q, r;
 
-    q = c89trunc((double)i/j);
+    q = trunc((double)i/j);
     r = i - j * q;
 
     return pic_values(pic, 2, pic_float_value(pic, q), pic_float_value(pic, r));
@@ -116,7 +105,7 @@ pic_number_trunc(pic_state *pic)
   if (e) {
     return pic_int_value(pic, (int)f);
   } else {
-    return pic_float_value(pic, c89trunc(f));
+    return pic_float_value(pic, trunc(f));
   }
 }
 
@@ -131,7 +120,7 @@ pic_number_round(pic_state *pic)
   if (e) {
     return pic_int_value(pic, (int)f);
   } else {
-    return pic_float_value(pic, c89round(f));
+    return pic_float_value(pic, round(f));
   }
 }
 

--- a/contrib/20.r7rs/scheme/base.scm
+++ b/contrib/20.r7rs/scheme/base.scm
@@ -922,6 +922,7 @@
           read-bytevector!
 
           write
+          display
           newline
           write-char
           write-string

--- a/lib/bool.c
+++ b/lib/bool.c
@@ -47,7 +47,7 @@ pic_eqv_p(pic_state *PIC_UNUSED(pic), pic_value x, pic_value y)
     x_v = pic_float(pic, x);
     y_v = pic_float(pic, y);
     if (c89isnan(x_v) && c89isnan(y_v))
-      return 1;
+      return true;
     return x_v == y_v;
   case PIC_TYPE_INT:
     return pic_int(pic, x) == pic_int(pic, y);


### PR DESCRIPTION
* string->number and related functions assumed long was larger than int, which is not always the case on 32bit systems. Used int64 instead
* Overflow of strtoll handled via errno to improve reliability
* In setup.h include stdint.h in all cases for int64_t and uint64_t types
  * int64_t and uint64_t now unconditionally defined in stdint.h
* When !PIC_USE_LIBC
  * add strtoll function
  * handle overflow in existing strtol and new strtoll setting value to INT/LONG_MAX and setting errno
* Removed c89trunc and c89round as they had limited range
  * Now use the system libraries
* Export display from scheme base, write exported in previous update